### PR TITLE
Changed centering calculation to use app.screen dimensions.

### DIFF
--- a/src/basic/App.fs
+++ b/src/basic/App.fs
@@ -17,8 +17,6 @@ Browser.document.body.appendChild(app.view) |> ignore
 // create a new Sprite from an image path
 let bunny = PIXI.Sprite.fromImage("../img/fable_logo_small.png")
 
-let renderer : PIXI.WebGLRenderer = !!app.renderer
-
 // center the sprite's anchor point
 bunny.anchor.set(0.5)
 bunny.x <- app.screen.width * 0.5

--- a/src/basic/App.fs
+++ b/src/basic/App.fs
@@ -21,8 +21,8 @@ let renderer : PIXI.WebGLRenderer = !!app.renderer
 
 // center the sprite's anchor point
 bunny.anchor.set(0.5)
-bunny.x <- renderer.width * 0.5
-bunny.y <- renderer.height * 0.5
+bunny.x <- app.screen.width * 0.5
+bunny.y <- app.screen.height * 0.5
 
 app.stage.addChild(bunny) |> ignore
 


### PR DESCRIPTION
It was pointed out to me that the [fable-pixi template](https://github.com/inchingforward/fable-pixi-template) I wrote should be using the screen dimensions rather than the renderer dimensions since the renderer width is in real pixels, not CSS pixels that the stage coords use.  The Pixi devs originally had their example using the renderer dimensions, too--they [have since changed their basic example](https://pixijs.io/examples/#/basics/basic.js).  